### PR TITLE
TextPropertiesのフォントサイズをスライダーから数値入力に変更

### DIFF
--- a/src/components/properties/TextProperties.svelte
+++ b/src/components/properties/TextProperties.svelte
@@ -198,8 +198,9 @@
         max={200}
         step={1}
         oninput={(e) => {
-          const v = Number((e.target as HTMLInputElement).value);
-          if (v >= 8 && v <= 200) updateStyle({ fontSize: v });
+          const v = Math.min(200, Math.max(8, Number((e.target as HTMLInputElement).value)));
+          (e.target as HTMLInputElement).value = String(v);
+          updateStyle({ fontSize: v });
         }}
         class="w-20 px-2 py-1 text-sm bg-bg-secondary border border-bg-tertiary rounded text-text-primary text-right"
       />

--- a/src/components/properties/TextProperties.svelte
+++ b/src/components/properties/TextProperties.svelte
@@ -188,15 +188,23 @@
   </div>
 
   <!-- サイズ -->
-  <div>
-    <Slider
-      label="サイズ"
-      value={layer.style.fontSize}
-      min={8}
-      max={200}
-      unit="px"
-      onchange={(value) => updateStyle({ fontSize: value })}
-    />
+  <div class="flex flex-col gap-1">
+    <label class="text-sm text-text-secondary">サイズ</label>
+    <div class="flex items-center gap-2">
+      <input
+        type="number"
+        value={layer.style.fontSize}
+        min={8}
+        max={200}
+        step={1}
+        oninput={(e) => {
+          const v = Number((e.target as HTMLInputElement).value);
+          if (v >= 8 && v <= 200) updateStyle({ fontSize: v });
+        }}
+        class="w-20 px-2 py-1 text-sm bg-bg-secondary border border-bg-tertiary rounded text-text-primary text-right"
+      />
+      <span class="text-sm text-text-secondary">px</span>
+    </div>
   </div>
 
   <!-- 色 -->


### PR DESCRIPTION
## Summary

- `TextProperties.svelte` のフォントサイズ指定をスライダー (`Slider`) から `<input type="number">` に変更
- 入力範囲は従来と同じ 8px〜200px
- 入力後に即座に `updateStyle` が呼ばれ、オートセーブが走る

https://claude.ai/code/session_016FeeVoF4EJuDqHhe9iBYnx

---
_Generated by [Claude Code](https://claude.ai/code/session_016FeeVoF4EJuDqHhe9iBYnx)_